### PR TITLE
feat: show createdAt and updatedAt in user response

### DIFF
--- a/src/features/user/data/repository/user.rs
+++ b/src/features/user/data/repository/user.rs
@@ -62,6 +62,8 @@ impl IUserRepository for UserRepository {
                 email: user.email,
                 photo: user.photo,
                 verified: user.verified,
+                created_at: user.created_at,
+                updated_at: user.updated_at,
             })
             .map_err(|_| APIError::UserNotFoundError)
     }
@@ -83,6 +85,8 @@ impl IUserRepository for UserRepository {
                         email: updated_user.email,
                         photo: updated_user.photo,
                         verified: updated_user.verified,
+                        created_at: updated_user.created_at,
+                        updated_at: updated_user.updated_at,
                     })
                     .map_err(|_| APIError::InternalError)
             })
@@ -125,6 +129,8 @@ impl IUserRepository for UserRepository {
                         email: user.email.clone(),
                         photo: user.photo.clone(),
                         verified: user.verified,
+                        created_at: user.created_at,
+                        updated_at: user.updated_at,
                     })
                     .collect(),
                 total,

--- a/src/features/user/domain/entity/user.rs
+++ b/src/features/user/domain/entity/user.rs
@@ -7,7 +7,9 @@ camel_case_struct!(UserEntity {
     name: String,
     email: String,
     photo: String,
-    verified: bool
+    verified: bool,
+    created_at: chrono::NaiveDateTime,
+    updated_at: chrono::NaiveDateTime,
 });
 
 camel_case_struct!(UsersEntity {


### PR DESCRIPTION
## What it does

- return createdAt and updatedAt related to user response

## How to test

1. fetch the user API like: user or users
2. observe the response
3.

## Screenshot

![image](https://github.com/user-attachments/assets/7f787762-9bdc-4af4-87e8-aa34815dfb6c)
