### PR TITLE
feat: support add photo when register

### DIFF
--- a/src/features/user/data/models/user.rs
+++ b/src/features/user/data/models/user.rs
@@ -27,11 +27,8 @@ pub struct User {
 
 impl User {
     pub fn hash_password(&mut self) -> AppResult<()> {
-        if let Ok(hashed_password) = hash(self.password.as_bytes(), DEFAULT_COST) {
-            self.password = hashed_password;
-            Ok(())
-        } else {
-            Err(APIError::InternalError)
-        }
+        hash(self.password.as_bytes(), DEFAULT_COST)
+            .map(|hashed_password| self.password = hashed_password)
+            .map_err(|_| APIError::InternalError)
     }
 }

--- a/src/features/user/domain/repository/user.rs
+++ b/src/features/user/domain/repository/user.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub trait IUserRepository: Send + Sync {
-    fn create(&self, params: RegisterParams) -> AppResult<String>;
+    fn create(&self, params: RegisterParams) -> AppResult<UserEntity>;
     fn find_user_by_id(&self, user_id: Uuid) -> AppResult<UserEntity>;
     fn update_user(&self, user_id: Uuid, params: UpdateUserParams) -> AppResult<UserEntity>;
     fn delete(&self, user_id: Uuid) -> AppResult<String>;

--- a/src/features/user/domain/usecase/dto.rs
+++ b/src/features/user/domain/usecase/dto.rs
@@ -20,7 +20,8 @@ camel_case_struct!(RegisterParams {
       required(message = "field is required"),
       length(min = 3,max = 20,message = "Password must be between 3 and 20 characters"),
     )]
-    password: Option<String>
+    password: Option<String>,
+    photo: Option<String>,
 });
 
 impl From<RegisterParams> for User {
@@ -33,7 +34,7 @@ impl From<RegisterParams> for User {
             role: String::from("user"),
             created_at: Utc::now().naive_utc(),
             updated_at: Utc::now().naive_utc(),
-            photo: String::from("default.png"),
+            photo: params.photo.unwrap(),
             verified: false,
         }
     }

--- a/src/features/user/domain/usecase/dto.rs
+++ b/src/features/user/domain/usecase/dto.rs
@@ -26,6 +26,7 @@ camel_case_struct!(RegisterParams {
 
 impl From<RegisterParams> for User {
     fn from(params: RegisterParams) -> Self {
+        let default_photo = String::from("https://user-images.githubusercontent.com/1531684/281937715-f53c55be-4b70-43b5-bb50-11706fb71ada.png");
         User {
             id: Uuid::new_v4(),
             email: params.email.unwrap(),
@@ -34,7 +35,7 @@ impl From<RegisterParams> for User {
             role: String::from("user"),
             created_at: Utc::now().naive_utc(),
             updated_at: Utc::now().naive_utc(),
-            photo: params.photo.unwrap(),
+            photo: params.photo.unwrap_or(default_photo),
             verified: false,
         }
     }

--- a/src/features/user/domain/usecase/interface.rs
+++ b/src/features/user/domain/usecase/interface.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub trait IUserService: Send + Sync {
-    fn register(&self, params: RegisterParams) -> AppResult<String>;
+    fn register(&self, params: RegisterParams) -> AppResult<UserEntity>;
     fn find_user_by_id(&self, user_id: Uuid) -> AppResult<UserEntity>;
     fn update_user(&self, user_id: Uuid, params: UpdateUserParams) -> AppResult<UserEntity>;
     fn delete_user(&self, user_id: Uuid) -> AppResult<String>;

--- a/src/features/user/domain/usecase/service.rs
+++ b/src/features/user/domain/usecase/service.rs
@@ -27,7 +27,7 @@ impl UserService {
 }
 
 impl IUserService for UserService {
-    fn register(&self, params: RegisterParams) -> AppResult<String> {
+    fn register(&self, params: RegisterParams) -> AppResult<UserEntity> {
         params
             .validate()
             .map(|_| self.user_repo.create(params))

--- a/src/features/user/user_controller.rs
+++ b/src/features/user/user_controller.rs
@@ -23,7 +23,7 @@ pub async fn register(
         .di_container
         .user_service
         .register(params.0)
-        .map(|_| ResponseBody::<()>::success(None).into())
+        .map(|data| ResponseBody::success(Some(data)).into())
 }
 
 pub async fn get_user(auth: AuthMiddleware) -> AppResult<HttpResponse> {


### PR DESCRIPTION
## What it does

- [feat: return user data when register](https://github.com/lazycatlabs/auth_api/commit/94b1a1ff937f7400573fa5ca3192b0e805d5db99)
- [feat: add photo on register params](https://github.com/lazycatlabs/auth_api/commit/5205a794365e6bab9becac345b63f3a5b3e205cf)
- [chore: replace if with map](https://github.com/lazycatlabs/auth_api/commit/d5b264968afe29e5397ba0817e06d03939dc769f)
- [feat: add default photo](https://github.com/lazycatlabs/auth_api/pull/9/commits/e7032e451b724813fe003596ad1cdc866057af57)

## How to test

1. hit register API and add photo in params
2. observe the response
3. the response should be return user data

## Screenshot

![image](https://github.com/user-attachments/assets/ab1bb3a4-f115-4e5e-9989-f26d7d6951e0)
