### PR TITLE
fix: resolve token validator when user logout

### DIFF
--- a/src/core/middlewares/auth.rs
+++ b/src/core/middlewares/auth.rs
@@ -68,7 +68,7 @@ impl FromRequest for AuthMiddleware {
 
             let user_id = di.auth_repository.verify_token(&token_data).map_err(|_| {
                 APIError::UnauthorizedMessage {
-                    message: "Token verification failed".to_string(),
+                    message: "The provided token has been revoked.".to_string(),
                 }
             })?;
 

--- a/src/features/auth/data/repository/auth_repository_impl.rs
+++ b/src/features/auth/data/repository/auth_repository_impl.rs
@@ -121,11 +121,11 @@ impl AuthRepositoryImpl for AuthRepository {
     }
 
     fn is_valid_login_session(&self, user: Uuid, login_session: Uuid) -> bool {
-        login_history::table
+        !login_history::table
             .filter(login_history_user_id.eq(&user))
             .filter(login_history_id.eq(&login_session))
-            .execute(&mut self.source.get().unwrap())
-            .is_ok()
+            .load::<LoginHistory>(&mut self.source.get().unwrap())
+            .map_err(|_| APIError::InternalError).unwrap().is_empty()
     }
 
     fn update_password(&self, user: Uuid, params: UpdatePasswordParams) -> AppResult<()> {


### PR DESCRIPTION
## What it does

- update error message when the used token is already revoked
- fix when validating the token 

## How to test

1. run the project
2. login
3. get user data
4. logout 
5. get user data
6. observe the view

## Screenshot
![image](https://github.com/user-attachments/assets/a586f946-359b-4311-a05a-18e653c9a2a2)

