### PR TITLE
feat: add config to disable modify the data

### DIFF
--- a/.env
+++ b/.env
@@ -25,4 +25,4 @@ MAIL_SECRET_KEY=your_mailjet_secret_key
 APP_HOST=localhost
 APP_PORT=8000
 
-ALLOW_MODIFIED=false
+IS_SUPPORT_MODIFIED=false

--- a/.env
+++ b/.env
@@ -24,3 +24,5 @@ MAIL_SECRET_KEY=your_mailjet_secret_key
 
 APP_HOST=localhost
 APP_PORT=8000
+
+ENABLE_REGISTER=false

--- a/.env
+++ b/.env
@@ -25,4 +25,4 @@ MAIL_SECRET_KEY=your_mailjet_secret_key
 APP_HOST=localhost
 APP_PORT=8000
 
-ENABLE_REGISTER=false
+ALLOW_MODIFIED=false

--- a/src/core/middlewares/general.rs
+++ b/src/core/middlewares/general.rs
@@ -14,6 +14,7 @@ use crate::{
     features::auth::data::models::general_token::GeneralToken,
 };
 
+#[allow(dead_code)]
 pub struct GeneralMiddleware {
     pub data: TokenData<GeneralToken>,
 }

--- a/src/features/user/data/repository/user_repository_impl.rs
+++ b/src/features/user/data/repository/user_repository_impl.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use chrono::Utc;
 use diesel::prelude::*;
 use diesel::{ExpressionMethods, RunQueryDsl};
@@ -37,6 +39,21 @@ impl UserRepositoryImpl for UserRepository {
         let mut user = User::from(params);
         let _ = user.hash_password();
         let email_register = user.email.clone();
+
+        let enable_register = env::var("ENABLE_REGISTER").expect("DATABASE_URL not found.") == "true";
+
+        if !enable_register {
+          // return mock user
+            return Ok(UserResponse {
+              id: user.id,
+              name: user.name,
+              email: user.email,
+              photo: user.photo,
+              verified: user.verified,
+              created_at: user.created_at,
+              updated_at: user.updated_at,
+          });
+        }
 
         diesel::insert_into(users::table)
             .values(&user)

--- a/src/features/user/data/repository/user_repository_impl.rs
+++ b/src/features/user/data/repository/user_repository_impl.rs
@@ -40,9 +40,10 @@ impl UserRepositoryImpl for UserRepository {
         let _ = user.hash_password();
         let email_register = user.email.clone();
 
-        let allow_modified = env::var("ALLOW_MODIFIED").expect("DATABASE_URL not found.") == "true";
+        let is_allow_modified =
+            env::var("IS_SUPPORT_MODIFIED").expect("DATABASE_URL not found.") == "true";
 
-        if !allow_modified {
+        if !is_allow_modified {
             // return mock user
             return Ok(UserResponse {
                 id: user.id,
@@ -95,11 +96,12 @@ impl UserRepositoryImpl for UserRepository {
     }
 
     fn update_user(&self, user_id: Uuid, params: UpdateUserParams) -> AppResult<UserResponse> {
-        let allow_modified = env::var("ALLOW_MODIFIED").expect("DATABASE_URL not found.") == "true";
+        let is_allow_modified =
+            env::var("IS_SUPPORT_MODIFIED").expect("DATABASE_URL not found.") == "true";
 
         self.find_user_by_id(user_id)
             .map(|user| {
-                if !allow_modified {
+                if !is_allow_modified {
                     // return mock response
                     return Ok(UserResponse {
                         id: user_id,
@@ -135,12 +137,16 @@ impl UserRepositoryImpl for UserRepository {
     }
 
     fn delete(&self, user_id: Uuid) -> AppResult<String> {
-        let allow_modified = env::var("ALLOW_MODIFIED").expect("DATABASE_URL not found.") == "true";
+        let is_allow_modified =
+            env::var("IS_SUPPORT_MODIFIED").expect("DATABASE_URL not found.") == "true";
 
         self.find_user_by_id(user_id)
             .map(|user| {
-                if !allow_modified {
-                    return Ok(format!("User with id '{}' deleted successfully", user.email));
+                if !is_allow_modified {
+                    return Ok(format!(
+                        "User with id '{}' deleted successfully",
+                        user.email
+                    ));
                 }
                 diesel::delete(users.find(user.id))
                     .execute(&mut self.source.get().unwrap())

--- a/src/features/user/data/repository/user_repository_impl.rs
+++ b/src/features/user/data/repository/user_repository_impl.rs
@@ -40,19 +40,19 @@ impl UserRepositoryImpl for UserRepository {
         let _ = user.hash_password();
         let email_register = user.email.clone();
 
-        let enable_register = env::var("ENABLE_REGISTER").expect("DATABASE_URL not found.") == "true";
+        let allow_modified = env::var("ALLOW_MODIFIED").expect("DATABASE_URL not found.") == "true";
 
-        if !enable_register {
-          // return mock user
+        if !allow_modified {
+            // return mock user
             return Ok(UserResponse {
-              id: user.id,
-              name: user.name,
-              email: user.email,
-              photo: user.photo,
-              verified: user.verified,
-              created_at: user.created_at,
-              updated_at: user.updated_at,
-          });
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                photo: user.photo,
+                verified: user.verified,
+                created_at: user.created_at,
+                updated_at: user.updated_at,
+            });
         }
 
         diesel::insert_into(users::table)
@@ -95,8 +95,23 @@ impl UserRepositoryImpl for UserRepository {
     }
 
     fn update_user(&self, user_id: Uuid, params: UpdateUserParams) -> AppResult<UserResponse> {
+        let allow_modified = env::var("ALLOW_MODIFIED").expect("DATABASE_URL not found.") == "true";
+
         self.find_user_by_id(user_id)
             .map(|user| {
+                if !allow_modified {
+                    // return mock response
+                    return Ok(UserResponse {
+                        id: user_id,
+                        name: params.name.unwrap_or("".to_string()),
+                        email: user.email.to_string(),
+                        photo: params.photo.unwrap_or("".to_string()),
+                        verified: params.verified.unwrap_or(false),
+                        created_at: user.created_at,
+                        updated_at: Utc::now().naive_utc(),
+                    });
+                }
+
                 diesel::update(users.find(user.id))
                     .set((
                         name.eq(params.name.unwrap_or(user.name)),
@@ -120,8 +135,13 @@ impl UserRepositoryImpl for UserRepository {
     }
 
     fn delete(&self, user_id: Uuid) -> AppResult<String> {
+        let allow_modified = env::var("ALLOW_MODIFIED").expect("DATABASE_URL not found.") == "true";
+
         self.find_user_by_id(user_id)
             .map(|user| {
+                if !allow_modified {
+                    return Ok(format!("User with id '{}' deleted successfully", user.email));
+                }
                 diesel::delete(users.find(user.id))
                     .execute(&mut self.source.get().unwrap())
                     .map(|_| format!("User with email '{}' deleted successfully", user.email))


### PR DESCRIPTION
## What it does

- add config to disable or modify the data on
  - add new user
  - edit user data
  - delete user data

## How to test

1. run the project
2. login and do some modified like add, edit, or delete the user data
3. observe the view
4. should return a response but data on the database is not changed
5. you can check it by fetch users API

## Screenshot
### Modified 
![image](https://github.com/user-attachments/assets/dff255bb-6e87-4612-ad65-2aa5c9286954)

### Users
![image](https://github.com/user-attachments/assets/711f7c32-e56b-40ae-bd3b-171b79ea28c5)

